### PR TITLE
add option to filter stats by filename

### DIFF
--- a/repoze/profile/profiler.html
+++ b/repoze/profile/profiler.html
@@ -53,6 +53,10 @@
               </select>
             </td>
             <td>
+              <strong>Filter</strong>:
+              <input type="text" name="filename" meld:id="filename" placeholder="filename part" />
+            </td>
+            <td>
               <input type="submit" name="submit" value="Update"/>
             </td>
             <td>

--- a/repoze/profile/profiler.py
+++ b/repoze/profile/profiler.py
@@ -60,6 +60,7 @@ class AccumulatingProfileMiddleware(object):
         full_dirs = int(querydata.get('full_dirs', 0))
         sort = querydata.get('sort', 'time')
         clear = querydata.get('clear', None)
+        filename = querydata.get('filename', None)
         limit = int(querydata.get('limit', 100))
         mode = querydata.get('mode', 'stats')
         if output is None:
@@ -84,7 +85,7 @@ class AccumulatingProfileMiddleware(object):
                 orig_stdout = sys.stdout # python 2.4
                 sys.stdout = output
                 print_fn = getattr(stats, 'print_%s' % mode)
-                print_fn(limit)
+                print_fn(filename, limit)
             finally:
                 sys.stdout = orig_stdout
 
@@ -106,10 +107,12 @@ class AccumulatingProfileMiddleware(object):
                 formelements.fillmeldhtmlform(sort=sort,
                                               limit=str(limit),
                                               full_dirs=True,
+                                              filename=filename or '',
                                               mode=mode)
             else:
                 formelements.fillmeldhtmlform(sort=sort,
                                               limit=str(limit),
+                                              filename=filename or '',
                                               mode=mode)
 
             profiledata = root.findmeld('profiledata')


### PR DESCRIPTION
pretty simple feature; I wanted to be able to see which parts of my app were slowest, but all the top results are calls deep in the internals of third-party libraries (eg sqlalchemy). This patch allows filtering by filename so that I can limit output to my app's files (according to what's displayed - if you don't display folders, you can't filter on folders. Not sure how to get around this)
