### PR TITLE
python3-specific fixes

### DIFF
--- a/repoze/profile/profiler.py
+++ b/repoze/profile/profiler.py
@@ -189,7 +189,7 @@ class ProfileMiddleware(object):
                     conv = pyprof2calltree.CalltreeConverter(stats)
                     grind = None
                     try:
-                        grind = file(self.cachegrind_filename, 'wb')
+                        grind = open(self.cachegrind_filename, 'w')
                         conv.output(grind)
                     finally:
                         if grind is not None:


### PR DESCRIPTION
Remove usage of 'file' keyword, which does not exist in python3. Open grind file in text mode as this is what the pyprof2calltree.CalltreeConverter.output method expects (or seems too)